### PR TITLE
Flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ printed immediately.
 To listen to messages, you can use this command:
 
 ```
-curl -N localhot:9013/system/icc/notify?meeting_id=5
+curl -N localhot:9007/system/icc/notify?meeting_id=5
 ```
 
 The meeting_id query argument is optional.
@@ -97,7 +97,7 @@ Each other other line is one notify message. It has the following format:
 To publish a message, you can use the following request:
 
 ```
-curl localhost:9013/system/icc/notify/publish -d '{
+curl localhost:9007/system/icc/notify/publish -d '{
   "channel_id": "STRING_SEE_ABOVE",
   "to_meeting": 5,
   "to_users": [3,4],
@@ -124,7 +124,7 @@ from the autoupdate-service repo.
 To listen to messages, you can use this command:
 
 ```
-curl -N localhot:9013/system/icc/notify?meeting_id=5
+curl -N localhot:9007/system/icc/notify?meeting_id=5
 ```
 
 The meeting_id argument is required.
@@ -138,7 +138,7 @@ The returned messages have the format:
 To send applause, use:
 
 ```
-curl localhost:9013/system/icc/applause/send?meeting_id=1
+curl localhost:9007/system/icc/applause/send?meeting_id=1
 ```
 
 The argument meeting_id is required.
@@ -154,8 +154,8 @@ TODO
 
 The Service uses the following environment variables:
 
-* `ICC_PORT`: Lets the service listen on port 9013. The default is
-  `9013`.
+* `ICC_PORT`: Lets the service listen on port 9007. The default is
+  `9007`.
 * `ICC_HOST`: The device where the service starts. The default is am
   empty string which starts the service on any device.
 * `ICC_REDIS_HOST`: The host of the redis instance to save icc messages. The

--- a/internal/notify/http.go
+++ b/internal/notify/http.go
@@ -49,6 +49,7 @@ func HandleReceive(mux *http.ServeMux, notify Receiver, auth icchttp.Authenticat
 			icchttp.Error(w, fmt.Errorf("sending channel id: %w", err))
 			return
 		}
+		w.(http.Flusher).Flush()
 
 		encoder := json.NewEncoder(w)
 
@@ -63,6 +64,8 @@ func HandleReceive(mux *http.ServeMux, notify Receiver, auth icchttp.Authenticat
 				icchttp.ErrorNoStatus(w, fmt.Errorf("sending message: %w", err))
 				return
 			}
+
+			w.(http.Flusher).Flush()
 		}
 	})
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -91,7 +91,7 @@ func Run(ctx context.Context, environment []string, secret func(name string) (st
 // defaut values.
 func defaultEnv(environment []string) map[string]string {
 	env := map[string]string{
-		"ICC_PORT": "9013",
+		"ICC_PORT": "9007",
 
 		"ICC_REDIS_HOST": "localhost",
 		"ICC_REDIS_PORT": "6379",


### PR DESCRIPTION
Fixes #30 

Also sets the default port to 9007. See https://github.com/OpenSlides/OpenSlides/wiki/DE%3AKonzept-OpenSlides-4#default-ports

@gsiv and @peb-adr I set a wrong default port. The current default port is 9013, which is the port of the vote-servie. I don't think that this change will be any problem, since you set the default port in the proxy: https://github.com/OpenSlides/OpenSlides/blob/fd3371dd0b11f49e6cbaccdafed4d3c966efe6c4/proxy/entrypoint#L15

But I think you should change them in the main repo (low priority)

@normanjaeckel the same for the manage-service: https://github.com/OpenSlides/openslides-manage-service/blob/16ad83cb13d18588fdb743e099a059a028eac88c/pkg/config/default-config.yml#L74