### PR TITLE
fix path for healthcheck

### DIFF
--- a/internal/icchttp/http.go
+++ b/internal/icchttp/http.go
@@ -112,7 +112,7 @@ func HealthClient(ctx context.Context, useHTTPS bool, host, port string, insecur
 	req, err := http.NewRequestWithContext(
 		ctx,
 		"GET",
-		fmt.Sprintf("%s://%s:%s/system/vote/health", proto, host, port),
+		fmt.Sprintf("%s://%s:%s/system/icc/health", proto, host, port),
 		nil,
 	)
 	if err != nil {


### PR DESCRIPTION
the icc service didn't get into running state as health checks failed.
With this change I can already confirm the container will start up.

@ostcar please confirm my guess that this is just a copy-paste error and merge if so ;) .