### PR TITLE
Use perm

### DIFF
--- a/internal/iccerror/error.go
+++ b/internal/iccerror/error.go
@@ -56,7 +56,7 @@ type MessageError struct {
 // NewMessageError creates an error of a specific type with a different message.
 //
 // This are messages, that should be send to the client.
-func NewMessageError(t TypeError, format string, a ...interface{}) error {
+func NewMessageError(t TypeError, format string, a ...any) error {
 	return MessageError{
 		t,
 		fmt.Sprintf(format, a...),

--- a/internal/icclog/log.go
+++ b/internal/icclog/log.go
@@ -24,7 +24,7 @@ func SetInfoLogger(l *log.Logger) {
 }
 
 // Info prints output that is important for the user.
-func Info(format string, a ...interface{}) {
+func Info(format string, a ...any) {
 	if infoLogger == nil {
 		return
 	}
@@ -34,7 +34,7 @@ func Info(format string, a ...interface{}) {
 // Debug prints output that is important for development and debugging.
 //
 // If EnableDebug() was not called, this function is a noop.
-func Debug(format string, a ...interface{}) {
+func Debug(format string, a ...any) {
 	if debugLogger == nil {
 		return
 	}

--- a/internal/notify/channel_id.go
+++ b/internal/notify/channel_id.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 )
 
 // channelID is an id for a notify channel.
@@ -52,8 +51,6 @@ func (c *cIDGen) generate(uid int) channelID {
 }
 
 func (c *cIDGen) buildHostID() {
-	rand.Seed(time.Now().UnixNano())
-
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	const length = 8
 

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/OpenSlides/openslides-icc-service/internal/iccerror"
@@ -109,7 +110,7 @@ func (n *Notify) Publish(r io.Reader, uid int) error {
 
 	bs, err := json.Marshal(message)
 	if err != nil {
-		return fmt.Errorf("can not marshal notify message: %v", err)
+		return fmt.Errorf("marshal notify message: %v", err)
 	}
 
 	icclog.Debug("Saving notify message: `%s`", bs)
@@ -147,17 +148,14 @@ func (m Message) forMe(meetingID, uid int, cID channelID) bool {
 		return true
 	}
 
-	for _, toUID := range m.ToUsers {
-		if toUID == uid {
-			return true
-		}
+	if slices.Contains(m.ToUsers, uid) {
+		return true
 	}
 
-	for _, toCID := range m.ToChannels {
-		if toCID == cID.String() {
-			return true
-		}
+	if slices.Contains(m.ToChannels, cID.String()) {
+		return true
 	}
+
 	return false
 }
 

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -12,12 +12,9 @@ import (
 )
 
 func TestSend(t *testing.T) {
-	shutdownCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	backend := newBackendStrub()
 	n, bg := notify.New(backend)
-	go bg(shutdownCtx, nil)
+	go bg(t.Context(), nil)
 
 	t.Run("invalid json", func(t *testing.T) {
 		defer backend.reset()
@@ -44,7 +41,7 @@ func TestSend(t *testing.T) {
 
 		err := n.Publish(strings.NewReader(`
 		{
-			"to_users": [2], 
+			"to_users": [2],
 			"message": "hans"
 		}`), 1)
 
@@ -60,7 +57,7 @@ func TestSend(t *testing.T) {
 		err := n.Publish(strings.NewReader(`
 		{
 			"channel_id": "abc",
-			"to_users": [2], 
+			"to_users": [2],
 			"message": "hans"
 		}`), 1)
 
@@ -75,7 +72,7 @@ func TestSend(t *testing.T) {
 		err := n.Publish(strings.NewReader(`
 		{
 			"channel_id": "server:1:2",
-			"to_users": [2], 
+			"to_users": [2],
 			"message": "hans"
 		}`), 1)
 
@@ -91,7 +88,7 @@ func TestSend(t *testing.T) {
 		{
 			"channel_id": "server:1:2",
 			"name": "message-name",
-			"to_users": [2], 
+			"to_users": [2],
 			"message": "hans"
 		}`), 1)
 
@@ -111,12 +108,9 @@ func TestSend(t *testing.T) {
 }
 
 func TestReceive(t *testing.T) {
-	shutdownCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	backend := newBackendStrub()
 	n, bg := notify.New(backend)
-	go bg(shutdownCtx, nil)
+	go bg(t.Context(), nil)
 
 	_, next := n.Receive(1, 2)
 

--- a/internal/redis/redis_test.go
+++ b/internal/redis/redis_test.go
@@ -38,12 +38,9 @@ func TestICC(t *testing.T) {
 	redisConn.Wait(context.Background())
 
 	t.Run("Receive blocks", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
 		done := make(chan error)
 		go func() {
-			_, err := redisConn.NotifyReceive(ctx)
+			_, err := redisConn.NotifyReceive(t.Context())
 			done <- err
 		}()
 
@@ -81,9 +78,6 @@ func TestICC(t *testing.T) {
 	})
 
 	t.Run("Receive gets a send message", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
 		type receiveReturn struct {
 			message []byte
 			err     error
@@ -91,7 +85,7 @@ func TestICC(t *testing.T) {
 
 		done := make(chan receiveReturn)
 		go func() {
-			message, err := redisConn.NotifyReceive(ctx)
+			message, err := redisConn.NotifyReceive(t.Context())
 			done <- receiveReturn{message, err}
 		}()
 

--- a/internal/redis/stream.go
+++ b/internal/redis/stream.go
@@ -5,28 +5,28 @@ import (
 )
 
 // stream parses a redis stream object.
-func stream(reply interface{}, err error) (string, []byte, error) {
+func stream(reply any, err error) (string, []byte, error) {
 	if err != nil {
 		return "", nil, err
 	}
 	if reply == nil {
 		return "", nil, fmt.Errorf("no data returned")
 	}
-	streams, ok := reply.([]interface{})
+	streams, ok := reply.([]any)
 	if !ok {
 		return "", nil, fmt.Errorf("invalid input. Data has to be a list, not %T", reply)
 	}
 	if len(streams) == 0 {
 		return "", nil, fmt.Errorf("invalid input. No stream in data")
 	}
-	stream1, ok := streams[0].([]interface{})
+	stream1, ok := streams[0].([]any)
 	if !ok {
 		return "", nil, fmt.Errorf("invalid input. Stream has to be a two-tuple, not %T", streams[0])
 	}
 	if len(stream1) != 2 {
 		return "", nil, fmt.Errorf("invalid input. Stream has to be a two-tuple, got %d elements", len(stream1))
 	}
-	data, ok := stream1[1].([]interface{})
+	data, ok := stream1[1].([]any)
 	if !ok {
 		return "", nil, fmt.Errorf("invalid input. Stream data has to be a list, got %T", stream1[1])
 	}
@@ -36,7 +36,7 @@ func stream(reply interface{}, err error) (string, []byte, error) {
 	}
 
 	v := data[0]
-	element, ok := v.([]interface{})
+	element, ok := v.([]any)
 	if !ok {
 		return "", nil, fmt.Errorf("invalid input. Stream element has to be a two-tuple, got %T", v)
 	}
@@ -47,7 +47,7 @@ func stream(reply interface{}, err error) (string, []byte, error) {
 	if !ok {
 		return "", nil, fmt.Errorf("invalid input. Stream ID has to be a string, got %T", element[0])
 	}
-	kv, ok := element[1].([]interface{})
+	kv, ok := element[1].([]any)
 	if !ok {
 		return "", nil, fmt.Errorf("invalid input. Key values has to be a list of strings, got %T", element[1])
 	}


### PR DESCRIPTION
Changes the permission for applause.

Before, you had to be part of the meeting (was buggy). Now, you have to have to permission "meeting.can_see_livestream" to send or receive applause.

Fixes: #213 

Also update some code to use modern go